### PR TITLE
Gridlines not available.

### DIFF
--- a/src/Chart.StackedBar.js
+++ b/src/Chart.StackedBar.js
@@ -17,6 +17,12 @@
 		//Number - Width of the grid lines
 		scaleGridLineWidth : 1,
 
+        //Boolean - Whether to show horizontal lines (except X axis)
+		scaleShowHorizontalLines: true,
+
+		//Boolean - Whether to show vertical lines (except Y axis)
+		scaleShowVerticalLines: true,
+
 		//Boolean - If there is a stroke on each bar
 		barShowStroke : true,
 
@@ -412,6 +418,8 @@
 				lineColor : this.options.scaleLineColor,
 				gridLineWidth : (this.options.scaleShowGridLines) ? this.options.scaleGridLineWidth : 0,
 				gridLineColor : (this.options.scaleShowGridLines) ? this.options.scaleGridLineColor : "rgba(0,0,0,0)",
+                showHorizontalLines : this.options.scaleShowHorizontalLines,
+				showVerticalLines : this.options.scaleShowVerticalLines,
 				padding : (this.options.showScale) ? 0 : (this.options.barShowStroke) ? this.options.barStrokeWidth : 0,
 				showLabels : this.options.scaleShowLabels,
 				display : this.options.showScale


### PR DESCRIPTION
Added the variables for horizontal and vertical gridlines as are available in the Chart.js library.
